### PR TITLE
Cover automation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# pending
+* Look for built-in cover effect if not using PF2e Perception
+
 # v1.1.1
 * Improvements to README.md and table format
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # pending
 * Look for built-in cover effect if not using PF2e Perception
+* Let PF2e Perception autocalculate cover at combat start
 
 # v1.1.1
 * Improvements to README.md and table format

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,7 @@
-# pending
+# v1.2.0
 * Look for built-in cover effect if not using PF2e Perception
-* Let PF2e Perception autocalculate cover at combat start
+* If enabled, let PF2e Perception autocalculate cover at combat start
+* Show cover adjustments on initiative message
 
 # v1.1.1
 * Improvements to README.md and table format

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ When *Begin Encounter* is clicked on the combat tracker, this module appends GM-
 
 ![image](https://github.com/Eligarf/avoid-notice/assets/16523503/194d98aa-5a60-4564-9971-e368fa5b83f9)
 
-In the above, *Amiri's* stealth roll of 16 was successful against *monster* and *creature*, who had perception DC's of 10 and 13. It was not successful against *beast* or *grumpkin*, who in turn had perception DC's of 17 and 20. If *Amiri* had been behind standard cover relative to *beast*, then *Amiri* would have a +2 to stealth and thus would be `Undetected` instead, but would require the +4 from greater cover against *grumpkin* in order to be `Undetected` by it.
+In the above, *Amiri's* stealth roll of 16 was successful against *monster* and *creature*, who had perception DC's of 10 and 13. It was not successful against *beast* or *grumpkin*, who in turn had perception DC's of 17 and 20. If *Amiri* had been behind standard cover relative to *beast*, then *Amiri* would have a +2 to stealth and thus would be `Undetected` instead, but would require the +4 from greater cover against *grumpkin* in order to be `Undetected` by it. *PF2e Avoid Notice* will apply this bonus automatically if the token rolling stealth has an `Effect: Cover (Standard)` or `Effect: Cover (Greater)` effect on it unless *PF2e Perception* is active. 
 
 **NOTE: *PF2e Avoid Notice* does not trigger any cover calculations between tokens. It merely utilizes *PF2e Perception's* flags if they are already present**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Foundry Version](https://img.shields.io/endpoint?url=https://foundryshields.com/version?url=https%3A%2F%2Fraw.github.com%2Feligarf%2Favoid-notice%2Frelease%2Fmodule.json)
 
 ![Latest Downloads](https://img.shields.io/github/downloads/eligarf/avoid-notice/latest/total?color=blue&label=latest%20downloads)
-![Total Downloads](https://img.shields.io/github/downloads/eligarf/avoid-notice/total?color=blue&label=total%20downloads)
+![Forge Installs](https://img.shields.io/badge/dynamic/json?label=Forge%20Installs&query=package.installs&suffix=%25&url=https%3A%2F%2Fforge-vtt.com%2Fapi%2Fbazaar%2Fpackage%2Fpf2e-avoid-notice&colorB=4aa94a)
 # PF2e Avoid Notice
 
 A module for [FoundryVTT](https://foundryvtt.com) that shows results of initiative stealth check vs combatant perception DCs on the initiative messages when *Begin Encounter* is clicked.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ When *Begin Encounter* is clicked on the combat tracker, this module appends GM-
 
 In the above, *Amiri's* stealth roll of 16 was successful against *monster* and *creature*, who had perception DC's of 10 and 13. It was not successful against *beast* or *grumpkin*, who in turn had perception DC's of 17 and 20. If *Amiri* had been behind standard cover relative to *beast*, then *Amiri* would have a +2 to stealth and thus would be `Undetected` instead, but would require the +4 from greater cover against *grumpkin* in order to be `Undetected` by it. *PF2e Avoid Notice* will apply this bonus automatically if the token rolling stealth has an `Effect: Cover (Standard)` or `Effect: Cover (Greater)` effect on it unless *PF2e Perception* is active. 
 
-**NOTE: *PF2e Avoid Notice* does not trigger any cover calculations between tokens. It merely utilizes *PF2e Perception's* flags if they are already present**
-
 An *Unnoticed* setting controls whether or not to use `Unnoticed` rather than `Undetected` for stealth checks that beat both the target's perception DC and initiative. `Undetected` is always used if the stealth initiative roll beats the target's perception DC but doesn't beat the target's initiative roll.
 
 ## PF2e Perception
@@ -25,3 +23,4 @@ The 'Pathfinder on Foundry VTT Community and Volunteer Development Server' disco
 * *PF2e Avoid Notice* will set the appropriate visibility flags on the combatant tokens to reflect the detection status determined by stealth initiative checks.
 * An *Override* setting allows *PF2e Avoid Notice* to override existing *PF2e Perception* visibility flags on tokens. Disabling this is useful if one wishes to setup any complicated situation beforehand and not get it stomped by the initiative rolls.
 * If *PF2e Perception* cover flags are found on a token using stealth for initiative, standard or greater cover bonuses will apply as appropriate against perception DCs.
+* If *Compute Cover at Combat Start* is selected, *`*PF2e Avoid Notice* will ignore existing cover flags and use *PF2e Perception* to calculate new ones for tokens using stealth as initiative for each token they are testing against

--- a/languages/en.json
+++ b/languages/en.json
@@ -20,6 +20,10 @@
     "override": {
       "name": "Override",
       "hint": "Allow 'PF2e Avoid Notice' to override any existing PF2e-perception visibility flags on a token"
+    },
+    "computeCover": {
+      "name": "Compute Cover at Combat Start",
+      "hint": "Use 'PF2e Perception' to automatically compute cover between tokens using stealth for initiative and non-allied Tokens. It is only used for this check, and will not utilize greater cover"
     }
   }
 }

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -135,6 +135,10 @@ Hooks.once('init', () => {
               break;
           }
         }
+        if (coverBonus) {
+          const oldDelta = stealther.initiative - target.dc;
+          target.oldDelta = (oldDelta < 0) ? `${oldDelta}` : `+${oldDelta}`
+        }
 
         // Handle failing to win at stealth
         const delta = stealther.initiative + coverBonus - target.dc;

--- a/templates/combat-start.hbs
+++ b/templates/combat-start.hbs
@@ -2,12 +2,16 @@
   <span><strong>{{title}}</strong></span>
   <table>
     <tbody>
-  {{#each targets as |target|}}
+      {{#each targets as |target|}}
       <tr>
         <td style="min-width:60px">{{target.name}}</td>
+        {{#if target.oldDelta}}
+        <td style="min-width:25px"><s>{{target.oldDelta}}</s><b>{{target.delta}}</b></td>
+        {{else}}
         <td style="min-width:25px">{{target.delta}}</td>
+        {{/if}}
       </tr>
-  {{/each}}
+      {{/each}}
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
* Look for built-in cover effect if not using PF2e Perception
* If enabled, let PF2e Perception autocalculate cover at combat start
* Show cover adjustments on initiative message