### PR TITLE
Add setting for using 'Avoid Notice' exploration activity

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v1.6.0
+* Add a setting to disable the requirement that PCs have an active `Avoid Notice` exploration activity to hide at combat start.
+
 # v1.5.0
 * Hazards are skipped as targets for avoiding notice and when unhiding combatants. Hazards with `stealth` for initiative still display a list of which combatants they avoid notice from.
 

--- a/languages/en.json
+++ b/languages/en.json
@@ -22,6 +22,10 @@
       "name": "Reveal combatant tokens at Combat Start",
       "hint": "Combatant tokens with disabled visibility will be revealed at combat start, allowing perception/stealth results to behave as expected"
     },
+    "requireActivity": {
+      "name": "Require 'Avoid Notice' exploration activity",
+      "hint": "PCs are required to set the 'Avoid Notice' exploration activity active to hide at combat start. If disabled, PCs instead need to use stealth for initiative."
+    },
     "override": {
       "name": "Override",
       "hint": "Allow 'PF2e Avoid Notice' to override any existing PF2e-perception visibility flags on a token"
@@ -33,6 +37,7 @@
     "schema": {
       "name": "Schema Version",
       "hint": "Set this to a previous version to force a data migration from the specified version to the current version"
-    }
+    },
+    "nonHider": "Needs to use Avoid Notice exploration activity if wanting to hide at combat start"
   }
 }


### PR DESCRIPTION
* Add a setting to disable the requirement that PCs have an active `Avoid Notice` exploration activity to hide at combat start.