### PR TITLE
Condition handler

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,4 +1,4 @@
-# pending
+# v1.8.0
 * Critical rolls on initiative affect the degree of success of the sneak evaluation
 * Added a condition handler setting, allowing a choice of how to handle setting the `hidden`, `undetected`, and `unnoticed` settings at your table.
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,7 @@
+# pending
+* Critical failure on initiative roll affects the sneak results
+* Add support for 'Perceptive' module
+
 # v1.7.0
 * Fixed a dumb typo preventing the 1.6 feature from working
 * If override is allowed, remove any pf2e-perception flags on a token if actor gets a condition item change to `hidden`, `undetected`, or `unnoticed`. This typically comes from using 'Assign Status Effects' on the token HUD; I use it to quickly clear out pf2e-perception's mix of hidden/undetected states after a token attacks by setting then clearing `hidden` in the token HUD.

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,6 +1,6 @@
 # pending
-* Critical failure on initiative roll affects the sneak results
-* Add support for 'Perceptive' module
+* Critical rolls on initiative affect the degree of success of the sneak evaluation
+* Added a condition handler setting, allowing a choice of how to handle setting the `hidden`, `undetected`, and `unnoticed` settings at your table.
 
 # v1.7.0
 * Fixed a dumb typo preventing the 1.6 feature from working

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -2,12 +2,13 @@ const CONSOLE_COLORS = ['background: #222; color: #80ffff', 'color: #fff'];
 const HIDDEN = ['action:hide', 'action:create-a-diversion', 'action:sneak'];
 const MODULE_ID = 'pf2e-avoid-notice';
 const PERCEPTION_ID = 'pf2e-perception';
+const PERCEPTIVE_ID = 'perceptive';
 
 // vObject = await fromUuid("ObjectID");
 
 // vToken = await fromUuid("TokenID");
 
-// game.modules.get("perceptive").api.PerceptiveFlags.addSpottedby(vObject, vToken)
+// game.modules.get(PERCEPTIVE_ID).api.PerceptiveFlags.addSpottedby(vObject, vToken)
 
 function colorizeOutput(format, ...args) {
   return [
@@ -88,6 +89,7 @@ Hooks.once('init', () => {
     const overridePerception = perceptionApi && game.settings.get(MODULE_ID, 'override');
     const computeCover = perceptionApi && game.settings.get(MODULE_ID, 'computeCover');
     const requireActivity = game.settings.get(MODULE_ID, 'requireActivity');
+    const perceptiveApi = game.modules.get("perceptive")?.api;
     let nonAvoidingPcs = [];
 
     let avoiders = encounter.combatants.contents.filter((c) =>
@@ -193,6 +195,9 @@ Hooks.once('init', () => {
           // Remove any existing perception flag as we are observed
           if (overridePerception && perceptionData && otherToken.id in perceptionData)
             otherUpdate[`flags.${PERCEPTION_ID}.data.-=${otherToken.id}`] = true;
+          if (perceptiveApi) {
+
+          }
         }
 
         // Normal fail is hidden
@@ -424,6 +429,8 @@ Hooks.once('setup', () => {
       default: false,
     });
   }
+  
+  const perceptive = game.modules.get(PERCEPTIVE_ID)?.active;
 
   game.settings.register(MODULE_ID, 'schema', {
     name: game.i18n.localize(`${MODULE_ID}.schema.name`),

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -3,6 +3,12 @@ const HIDDEN = ['action:hide', 'action:create-a-diversion', 'action:sneak'];
 const MODULE_ID = 'pf2e-avoid-notice';
 const PERCEPTION_ID = 'pf2e-perception';
 
+// vObject = await fromUuid("ObjectID");
+
+// vToken = await fromUuid("TokenID");
+
+// game.modules.get("perceptive").api.PerceptiveFlags.addSpottedby(vObject, vToken)
+
 function colorizeOutput(format, ...args) {
   return [
     `%c${MODULE_ID} %c|`,

--- a/languages/en.json
+++ b/languages/en.json
@@ -26,10 +26,13 @@
       "name": "Require 'Avoid Notice' exploration activity",
       "hint": "PCs are required to set the 'Avoid Notice' exploration activity active to hide at combat start. If disabled, PCs instead need to use stealth for initiative."
     },
-    "override": {
-      "name": "Override",
-      "perceptionHint": "Allow 'PF2e Avoid Notice' to override any existing 'PF2e-perception' visibility flags on a token",
-      "perceptiveHint": "Allow 'PF2e Avoid Notice' to override any existing 'perceptive' visibility flags on a token"
+    "conditionHandler": {
+      "name": "Condition Handler",
+      "hint": "Worst dc visually favors the sneakers, whereas best dc visually favors the seekers.",
+      "ignore": "Don't set the status conditions",
+      "best": "Use the best perception dc to determine the condition",
+      "worst": "Use the worst perception dc to determine the condition",
+      "perception": "Let the pf2e-perception module handle it"
     },
     "computeCover": {
       "name": "Compute Cover at Combat Start",

--- a/languages/en.json
+++ b/languages/en.json
@@ -28,7 +28,8 @@
     },
     "override": {
       "name": "Override",
-      "perceptionHint": "Allow 'PF2e Avoid Notice' to override any existing 'PF2e-perception' visibility flags on a token"
+      "perceptionHint": "Allow 'PF2e Avoid Notice' to override any existing 'PF2e-perception' visibility flags on a token",
+      "perceptiveHint": "Allow 'PF2e Avoid Notice' to override any existing 'perceptive' visibility flags on a token"
     },
     "computeCover": {
       "name": "Compute Cover at Combat Start",


### PR DESCRIPTION
* Critical rolls on initiative affect the degree of success of the sneak evaluation
* Added a condition handler setting, allowing a choice of how to handle setting the `hidden`, `undetected`, and `unnoticed` settings at your table.