### PR TITLE
Quick-tempered automation, autoroll spell damage

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,3 +1,6 @@
+# v1.13.0
+* Added an opt-in setting to enable autorolling of non-attack spell damage before saves are rolled.
+
 # v1.12.2
 * Update pl.json (thanks Lioheart)
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -1,5 +1,6 @@
 # v1.13.0
 * Added an opt-in setting to enable autorolling of non-attack spell damage before saves are rolled.
+* Added a rage setting to automate barbarians entering rage at combat start
 
 # v1.12.2
 * Update pl.json (thanks Lioheart)

--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ This module provides the GM a number of options in the game settings for automat
 * The [*Perceptive*](https://foundryvtt.com/packages/perceptive) module can be chosen to handle things. Its only limitation is not being able to manage `undetected` and `hidden` on an avoider at the same time, but it does handle mixing `observed` states with those others.
 * The *PF2e Perception* module can be selected. It handles multiple visibility states for a token.
 
-## Raise a Shield
-
-I've added support to automatically apply `Raise a shield` to PCs using `defend` at combat start. It doesn't really belong with a stealth module, but since I was mucking about with combat start I went ahead and added it because manually doing this every time bugged me. Do note that the shield effect won't automatically expire at the beginning of turn 1; the system doesn't seem to process turn-based expiration until round 2, so you will have to manually delete the effect if the `Raise a shield` action isn't taken on turn 1. It will automatically expire on turn 2 however.
-
 ## PF2e Perception
 
 The 'Pathfinder on Foundry VTT Community and Volunteer Development Server' discord server leads to the excellent unlisted module [PF2e Perception](https://github.com/reonZ/pf2e-perception). It isn't required for the overall operation of this module, but additional capabilities become available:
@@ -55,3 +51,15 @@ The 'Pathfinder on Foundry VTT Community and Volunteer Development Server' disco
 * If *PF2e Perception* cover flags are found on an avoider token, standard or greater cover bonuses will apply as appropriate against perception DCs. The are given higher priority than the system cover flag if both are on a token.
 * If *Compute Cover at Combat Start* is selected, *PF2e Avoid Notice* will ignore existing cover flags and use *PF2e Perception* to calculate new ones for avoider tokens for each token they are testing against
 * Manually adding or removing the `hidden`, `undetected`, or `unnoticed` status condition on the token HUD will cause *PF2e Avoid Notice* to clear out any existing *PF2e Perception* flags on that token
+
+# Misfit features
+
+These belong in some other module, but they are handy to me so I'm sharing.
+
+## Raise a Shield
+
+I've added support to automatically apply `Raise a shield` to PCs using `defend` at combat start. It doesn't really belong with a stealth module, but since I was mucking about with combat start I went ahead and added it because manually doing this every time bugged me. Do note that the shield effect won't automatically expire at the beginning of turn 1; the system doesn't seem to process turn-based expiration until round 2, so you will have to manually delete the effect if the `Raise a shield` action isn't taken on turn 1. It will automatically expire on turn 2 however.
+
+## Autoroll Spell Damage
+
+I added a game setting to enable autorolling damage on non-attack spells, which only rolls the damage if the message card from the spell cast has a 'Roll Damage' button when it is created. This works differently from the autoroll feature of *PF2e Workbench* since it immediately rolls the damage and doesn't wait for a saving throw roll to trigger the automatic damage roll. It is off by default to avoid upsetting GMs who want to hide more rolls, but I heartily recommend it.

--- a/README.md
+++ b/README.md
@@ -58,8 +58,12 @@ These belong in some other module, but they are handy to me so I'm sharing.
 
 ## Raise a Shield
 
-I've added support to automatically apply `Raise a shield` to PCs using `defend` at combat start. It doesn't really belong with a stealth module, but since I was mucking about with combat start I went ahead and added it because manually doing this every time bugged me. Do note that the shield effect won't automatically expire at the beginning of turn 1; the system doesn't seem to process turn-based expiration until round 2, so you will have to manually delete the effect if the `Raise a shield` action isn't taken on turn 1. It will automatically expire on turn 2 however.
+I've added support to automatically apply `Raise a shield` to PCs using `Defend` at combat start. It doesn't really belong with a stealth module, but since I was mucking about with combat start I went ahead and added it because manually doing this every time bugged me. Do note that the shield effect won't automatically expire at the beginning of turn 1; the system doesn't seem to process turn-based expiration until round 2, so you will have to manually delete the effect if the `Raise a shield` action isn't taken on turn 1. It will automatically expire on turn 2 however.
 
 ## Autoroll Spell Damage
 
 I added a game setting to enable autorolling damage on non-attack spells, which only rolls the damage if the message card from the spell cast has a 'Roll Damage' button when it is created. This works differently from the autoroll feature of *PF2e Workbench* since it immediately rolls the damage and doesn't wait for a saving throw roll to trigger the automatic damage roll. It is off by default to avoid upsetting GMs who want to hide more rolls, but I heartily recommend it.
+
+## Rage
+
+Automation can be enabled to have Barbarians with `Quick-Tempered` automatically enter `Rage` at combat start.

--- a/esmodules/combat.js
+++ b/esmodules/combat.js
@@ -182,9 +182,9 @@ async function raiseDefendingShields(pcs) {
 }
 
 async function enrageBarbarians(pcs) {
-  const barbarians = pcs.filter((c) => c.actor.items.some((i) => i?.system?.slug === "quick-tempered") && c.actor.items.some((i) => i?.system?.slug === "rage"));
+  const barbarians = pcs.filter((c) => c.actor.items.some((i) => i?.system?.slug === "quick-tempered"));
   for (const barbarian of barbarians) {
-    const rage = barbarian.actor.items.find((i) => i?.system?.slug === "rage");
+    const rage = barbarian.actor.items.find((i) => i?.system?.slug === "rage" && i?.system?.selfEffect);
     if (!rage) continue;
     const object = barbarian.token?._object;
     if (!object?.control) continue;

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -39,14 +39,15 @@ Hooks.once('init', () => {
     if (game.userId != id) return;
     if (!game.settings.get(MODULE_ID, 'autorollSpellDamage')) return;
     const pf2eFlags = message?.flags?.pf2e;
+
+    // Accept only spell casting of non-attack damaging spells
     if (!pf2eFlags?.casting) return;
     const originUuid = pf2eFlags?.origin?.uuid;
     const origin = originUuid ? await fromUuid(originUuid) : null;
     if (origin?.traits?.has("attack")) return;
-    const damage = origin?.system?.damage;
-    if (!damage) return;
-    log('createChatMessage', { message, origin });
     if (!message.content.includes('<button type="button" data-action="spell-damage" data-visibility="owner">')) return;
+
+    // Roll the damage!
     origin?.rollDamage({ target: message.token });
   });
 });

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -184,6 +184,15 @@ Hooks.once('setup', () => {
     default: false,
   });
 
+  game.settings.register(MODULE_ID, 'rage', {
+    name: game.i18n.localize(`${MODULE_ID}.rage.name`),
+    hint: game.i18n.localize(`${MODULE_ID}.rage.hint`),
+    scope: 'world',
+    config: true,
+    type: Boolean,
+    default: false,
+  });
+
   game.settings.register(MODULE_ID, 'logLevel', {
     name: game.i18n.localize(`${MODULE_ID}.logLevel.name`),
     scope: 'client',

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -34,27 +34,34 @@ function getPerceptiveApi() {
 
 export { MODULE_ID, PF2E_PERCEPTION_ID, PERCEPTIVE_ID, log, getPerceptionApi, getPerceptiveApi };
 
-// Hooks.once('init', () => {
-//   Hooks.on('createChatMessage', async (message, options, id) => {
-//     if (game.userId != id) return;
-//     log('createChatMessage', message);
-//     const context = message.flags.pf2e.context;
-//     const actorId = message?.actor?.id ?? message.speaker?.actor ?? '';
-//     switch (context?.type) {
-//       case 'perception-check':
-//         if (context?.options.includes('action:seek')) {
-//           log('perception-check', message);
-//         }
-//         break;
-//       case 'skill-check':
-//         const tags = context?.options.filter((t) => SKILL_ACTIONS.includes(t));
-//         if (tags.length > 0) {
-//           log('skill-check', tags);
-//         }
-//         break;
-//     }
-//   });
-// });
+Hooks.once('init', () => {
+  Hooks.on('createChatMessage', async (message, options, id) => {
+    if (game.userId != id) return;
+    const pf2eFlags = message?.flags?.pf2e;
+    if (!pf2eFlags?.casting) return;
+    const originUuid = pf2eFlags?.origin?.uuid;
+    const origin = originUuid ? await fromUuid(originUuid) : null;
+    if (origin?.traits?.has("attack")) return;
+    const damage = origin?.system?.damage;
+    if (!damage) return;
+    log('createChatMessage', { message, origin });
+    // const context = message.flags.pf2e.context;
+    // const actorId = message?.actor?.id ?? message.speaker?.actor ?? '';
+    // switch (context?.type) {
+    //   case 'perception-check':
+    //     if (context?.options.includes('action:seek')) {
+    //       log('perception-check', message);
+    //     }
+    //     break;
+    //   case 'skill-check':
+    //     const tags = context?.options.filter((t) => SKILL_ACTIONS.includes(t));
+    //     if (tags.length > 0) {
+    //       log('skill-check', tags);
+    //     }
+    //     break;
+    // }
+  });
+});
 
 function migrate(moduleVersion, oldVersion) {
 

--- a/esmodules/main.js
+++ b/esmodules/main.js
@@ -46,7 +46,7 @@ Hooks.once('init', () => {
     const damage = origin?.system?.damage;
     if (!damage) return;
     log('createChatMessage', { message, origin });
-    if (!message.content.includes('<button type="button" data-action="spell-damage" data-visibility="owner">Roll Damage</button>')) return;
+    if (!message.content.includes('<button type="button" data-action="spell-damage" data-visibility="owner">')) return;
     origin?.rollDamage({ target: message.token });
   });
 });

--- a/languages/en.json
+++ b/languages/en.json
@@ -32,8 +32,8 @@
       "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
     },
     "rage": {
-      "name": "Quick-Tempered activates Rage at combat start",
-      "hint": ""
+      "name": "Enrage Barbarians at combat start",
+      "hint": "Requires the 'Quick-Tempered' and 'Rage' feats"
     },
     "requireActivity": {
       "name": "Require 'Avoid Notice' exploration activity",

--- a/languages/en.json
+++ b/languages/en.json
@@ -14,6 +14,11 @@
       "debug": "Debug level",
       "log": "Log level"
     },
+    "config": {
+      "general": "General Options",
+      "misfits": "Misfit Features",
+      "debug": "Debug Options"
+    },
     "useUnnoticed": {
       "name": "Unnoticed",
       "hint": "Use 'Unnoticed' rather than 'Undetected' when the stealth initiative check beats the target's perception DC and initiative"
@@ -26,6 +31,10 @@
       "name": "Raise PC shields when Defending",
       "hint": "Requires PCs to have held shields and have the Defend exploration activity active. They also need to have Raise A Shield in their encounter actions",
       "heldShield": "{actor} must have a shield equipped to {activity}."
+    },
+    "autorollSpellDamage": {
+      "name": "Autoroll spell damage",
+      "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
     },
     "requireActivity": {
       "name": "Require 'Avoid Notice' exploration activity",

--- a/languages/en.json
+++ b/languages/en.json
@@ -14,11 +14,6 @@
       "debug": "Debug level",
       "log": "Log level"
     },
-    "config": {
-      "general": "General Options",
-      "misfits": "Misfit Features",
-      "debug": "Debug Options"
-    },
     "useUnnoticed": {
       "name": "Unnoticed",
       "hint": "Use 'Unnoticed' rather than 'Undetected' when the stealth initiative check beats the target's perception DC and initiative"
@@ -35,6 +30,10 @@
     "autorollSpellDamage": {
       "name": "Autoroll spell damage",
       "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
+    },
+    "rage": {
+      "name": "Quick-Tempered activates Rage at combat start",
+      "hint": ""
     },
     "requireActivity": {
       "name": "Require 'Avoid Notice' exploration activity",
@@ -57,6 +56,11 @@
     "schema": {
       "name": "Schema Version",
       "hint": "Set this to a previous version to force a data migration from the specified version to the current version"
+    },
+    "config": {
+      "general": "General Options",
+      "misfits": "Misfit Features",
+      "debug": "Debug Options"
     }
   }
 }

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -14,6 +14,11 @@
       "debug": "Poziom debugowania",
       "log": "Poziom logów"
     },
+    "config": {
+      "general": "General Options",
+      "misfits": "Misfit Features",
+      "debug": "Debug Options"
+    },
     "useUnnoticed": {
       "name": "Niezauważony",
       "hint": "Użyj „Niezauważony” zamiast „Niewykryty”, gdy test inicjatywy Ukrycia przewyższa ST Percepcji i inicjatywę celu"
@@ -26,6 +31,10 @@
       "name": "Podnosi tarcze Postaci podczas Obrony",
       "hint": "Wymaga, aby Postacie trzymali tarcze i mieli aktywną akcję eksploracji Obrona. Muszą również posiadać akcję Podnieś tarczę w swoich akcjach spotkania.",
       "heldShield": "{actor} musi mieć wyposażoną tarczę, aby użyć {activity}."
+    },
+    "autorollSpellDamage": {
+      "name": "Autoroll spell damage",
+      "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
     },
     "requireActivity": {
       "name": "Wymóg użycia „Unikanie wykrycia” w akcjach eksploracji",

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -14,11 +14,6 @@
       "debug": "Poziom debugowania",
       "log": "Poziom logów"
     },
-    "config": {
-      "general": "General Options",
-      "misfits": "Misfit Features",
-      "debug": "Debug Options"
-    },
     "useUnnoticed": {
       "name": "Niezauważony",
       "hint": "Użyj „Niezauważony” zamiast „Niewykryty”, gdy test inicjatywy Ukrycia przewyższa ST Percepcji i inicjatywę celu"
@@ -35,6 +30,10 @@
     "autorollSpellDamage": {
       "name": "Autoroll spell damage",
       "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
+    },
+    "rage": {
+      "name": "Quick-Tempered activates Rage at combat start",
+      "hint": ""
     },
     "requireActivity": {
       "name": "Wymóg użycia „Unikanie wykrycia” w akcjach eksploracji",
@@ -57,6 +56,11 @@
     "schema": {
       "name": "Wersja schematu",
       "hint": "Ustaw to na poprzednią wersję, aby wymusić migrację danych z określonej wersji do wersji bieżącej."
+    },
+    "config": {
+      "general": "General Options",
+      "misfits": "Misfit Features",
+      "debug": "Debug Options"
     }
   }
 }

--- a/languages/pl.json
+++ b/languages/pl.json
@@ -32,8 +32,8 @@
       "hint": "Only for non-attack spells that have a Roll Damage button when the card is initially created."
     },
     "rage": {
-      "name": "Quick-Tempered activates Rage at combat start",
-      "hint": ""
+      "name": "Enrage Barbarians at combat start",
+      "hint": "Requires the 'Quick-Tempered' and 'Rage' feats"
     },
     "requireActivity": {
       "name": "Wymóg użycia „Unikanie wykrycia” w akcjach eksploracji",

--- a/module.json
+++ b/module.json
@@ -21,7 +21,7 @@
         "id": "pf2e",
         "type": "system",
         "compatibility": {
-          "verified": "6.4"
+          "verified": "6.5"
         }
       }
     ]


### PR DESCRIPTION
* Added an opt-in setting to enable autorolling of non-attack spell damage before saves are rolled.
* Added a rage setting to automate barbarians entering rage at combat start